### PR TITLE
Add: allow arbitrary output_fields when dynamic field is enabled

### DIFF
--- a/libs/milvus/langchain_milvus/retrievers/milvus_hybrid_search.py
+++ b/libs/milvus/langchain_milvus/retrievers/milvus_hybrid_search.py
@@ -96,9 +96,10 @@ class MilvusCollectionHybridSearchRetriever(BaseRetriever):
             self.text_field in collection_fields
         ), f"{self.text_field} is not a valid field in the collection."
         for field in self.output_fields:  # type: ignore[union-attr]
-            assert (
-                field in collection_fields
-            ), f"{field} is not a valid field in the collection."
+            if not self.collection.schema.enable_dynamic_field:
+                assert (
+                    field in collection_fields
+                ), f"{field} is not a valid field in the collection."
 
     def _get_output_fields(self) -> List[str]:
         if self.output_fields:


### PR DESCRIPTION
- Don't reject specified output fields that do not match the schema fields if the dynamic field is enabled

This allows to specify arbitrary metadata fields to be included in the output when building a retriever:

```py
retriever = vectorstore.as_retriever(
    search_type="similarity",
    search_kwargs={
        "k": 8,
        "ranker_type": "weighted",
        "ranker_params": {
            "weights": [
                0.5,  # Dense
                0.5,  # Sparse            ],
        },
        "output_fields": [
            "source",
            "section_title",
            "text",
            "pk",
        ],
    },
)
```