### PR TITLE
Removing `aadd_documents` to avoid Recursion Error

### DIFF
--- a/libs/milvus/langchain_milvus/vectorstores/milvus.py
+++ b/libs/milvus/langchain_milvus/vectorstores/milvus.py
@@ -1541,21 +1541,6 @@ class Milvus(VectorStore):
         metadatas = [doc.metadata for doc in documents]
         return self.add_texts(texts, metadatas, **kwargs)
 
-    async def aadd_documents(
-        self, documents: List[Document], **kwargs: Any
-    ) -> List[str]:
-        """Run more documents through the embeddings and add to the vectorstore.
-
-        Args:
-            documents: Documents to add to the vectorstore.
-
-        Returns:
-            List of IDs of the added texts.
-        """
-        texts = [doc.page_content for doc in documents]
-        metadatas = [doc.metadata for doc in documents]
-        return await self.aadd_texts(texts, metadatas, **kwargs)
-
     def get_pks(self, expr: str, **kwargs: Any) -> List[int] | None:
         """Get primary keys with expression
 


### PR DESCRIPTION
A `RecursionError` was being thrown because `aadd_document` was calling `aadd_texts` without any changes in its implementation from `add_documents`. To resolve this, `aadd_document` was removed, preventing the `RecursionError`, and the base method from `VectorStore` is now used instead.

Takes care of the following issue: https://github.com/langchain-ai/langchain/issues/28727