### PR TITLE
Update milvus.py

### DIFF
--- a/libs/milvus/langchain_milvus/vectorstores/milvus.py
+++ b/libs/milvus/langchain_milvus/vectorstores/milvus.py
@@ -380,6 +380,11 @@ class Milvus(VectorStore):
         # Create the connection to the server
         if connection_args is None:
             connection_args = DEFAULT_MILVUS_CONNECTION
+          
+        if "host" in connection_args:
+            uri = f"http://{connection_args['host']}:{connection_args.get('port', 19530)}"
+            connection_args = {"uri": uri}
+            
         self._milvus_client = MilvusClient(
             **connection_args,
         )


### PR DESCRIPTION
Allows to use connection_args as followed 

vectordb = Milvus(
                collection_name="my_milvus_collection",
                connection_args={"host": host_name, "port": port_name}
            )