### PR TITLE
Enable GPU_BRUTE_FORCE Milvus index 

### DIFF
--- a/libs/milvus/langchain_milvus/vectorstores/milvus.py
+++ b/libs/milvus/langchain_milvus/vectorstores/milvus.py
@@ -325,6 +325,7 @@ class Milvus(VectorStore):
             },
             "GPU_IVF_FLAT": {"metric_type": "L2", "params": {"nprobe": 10}},
             "GPU_IVF_PQ": {"metric_type": "L2", "params": {"nprobe": 10}},
+            "GPU_BRUTE_FORCE": {"metric_type": "L2", "params": {"nprobe": 10}},
             "SPARSE_INVERTED_INDEX": {
                 "metric_type": "IP",
                 "params": {"drop_ratio_build": 0.2},


### PR DESCRIPTION
This will empower users to insert data into the same collection while utilizing the GPU_BRUTE_FORCE index type in Milvus. GPU_BRUTE_FORCE is tailored for cases where extremely high recall is crucial, guaranteeing a recall of 1 by comparing each query with all vectors in the dataset.