### PR TITLE
Remove misleading docs

### DIFF
--- a/libs/milvus/langchain_milvus/vectorstores/milvus.py
+++ b/libs/milvus/langchain_milvus/vectorstores/milvus.py
@@ -211,17 +211,6 @@ class Milvus(VectorStore):
 
             * thud [{'baz': 'baz', 'pk': '2'}]
 
-    Search with filter:
-        .. code-block:: python
-
-            results = vector_store.similarity_search(query="thud",k=1,filter={"bar": "baz"})
-            for doc in results:
-                print(f"* {doc.page_content} [{doc.metadata}]")
-
-        .. code-block:: python
-
-            * thud [{'baz': 'baz', 'pk': '2'}]
-
     Search with score:
         .. code-block:: python
 


### PR DESCRIPTION
As far as I see the way to use filtering is with the `expr` parameter that take `str` expression (e.g.,: `'bar == "baz"'`). 
The `filter` parameter is not working (maybe it's an old option?). 