### PR TITLE
feat: add search by metadata function and test

### DIFF
--- a/libs/milvus/langchain_milvus/vectorstores/milvus.py
+++ b/libs/milvus/langchain_milvus/vectorstores/milvus.py
@@ -2063,3 +2063,44 @@ class Milvus(VectorStore):
                     self._as_list(builtin_function.output_field_names)
                 )
         return [field for field in fields if field not in forbidden_fields]
+
+    def search_by_metadata(
+        self, 
+        expr: str, 
+        fields: Optional[List[str]] = None, 
+        limit: int = 10
+    ) -> List[Document]:
+        """
+        Searches the Milvus vector store based on metadata conditions.
+
+        This function performs a metadata-based query using an expression
+        that filters stored documents without vector similarity.
+
+        Args:
+            expr (str): A filtering expression (e.g., `"city == 'Seoul'"`).
+            fields (Optional[List[str]]): List of fields to retrieve.
+                                          If None, retrieves all available fields.
+            limit (int): Maximum number of results to return.
+
+        Returns:
+            List[Document]: List of documents matching the metadata filter.
+        """
+        from pymilvus import MilvusException
+        
+        if self.col is None:
+            logger.debug("No existing collection to search.")
+            return []
+
+        # Default to retrieving all fields if none are provided
+        if fields is None:
+            fields = self.fields
+
+        try:
+            results = self.col.query(expr=expr, output_fields=fields, limit=limit)
+            return [
+                Document(page_content=result[self._text_field], metadata=result)
+                for result in results
+            ]
+        except MilvusException as e:
+            logger.error(f"Metadata search failed: {e}")
+            return []

--- a/libs/milvus/langchain_milvus/vectorstores/milvus.py
+++ b/libs/milvus/langchain_milvus/vectorstores/milvus.py
@@ -2065,10 +2065,7 @@ class Milvus(VectorStore):
         return [field for field in fields if field not in forbidden_fields]
 
     def search_by_metadata(
-        self, 
-        expr: str, 
-        fields: Optional[List[str]] = None, 
-        limit: int = 10
+        self, expr: str, fields: Optional[List[str]] = None, limit: int = 10
     ) -> List[Document]:
         """
         Searches the Milvus vector store based on metadata conditions.
@@ -2086,7 +2083,7 @@ class Milvus(VectorStore):
             List[Document]: List of documents matching the metadata filter.
         """
         from pymilvus import MilvusException
-        
+
         if self.col is None:
             logger.debug("No existing collection to search.")
             return []

--- a/libs/milvus/tests/integration_tests/vectorstores/test_milvus.py
+++ b/libs/milvus/tests/integration_tests/vectorstores/test_milvus.py
@@ -212,6 +212,7 @@ def test_milvus_get_pks(temp_milvus_db: Any) -> None:
     output = _get_pks(expr, docsearch)
     assert len(output) == 2
 
+
 def test_search_by_metadata(temp_milvus_db: Any) -> None:
     """
     Test metadata-based search in Milvus.


### PR DESCRIPTION
I have implemented a new method, search_by_metadata, for the Milvus vector store. This method allows users to query documents based on metadata conditions without performing a vector similarity search.

### Issue
#47 

### Key Features:
- Enables metadata filtering using an expression (e.g., "city == 'Seoul'").
- Supports specifying output fields to retrieve specific metadata.
- Returns results as a list of Document objects.

#### Code Implementation:
```
def search_by_metadata(
        self, 
        expr: str, 
        fields: Optional[List[str]] = None, 
        limit: int = 10
    ) -> List[Document]:
    """
    Searches the Milvus vector store based on metadata conditions.

    Args:
        expr (str): A filtering expression (e.g., `"city == 'Seoul'"`).
        fields (Optional[List[str]]): List of fields to retrieve.
                                      If None, retrieves all available fields.
        limit (int): Maximum number of results to return.

    Returns:
        List[Document]: List of documents matching the metadata filter.
    """
    from pymilvus import MilvusException
    if self.col is None:
        logger.debug("No existing collection to search.")
        return []

    if fields is None:
        fields = self.fields

    try:
        results = self.col.query(expr=expr, output_fields=fields, limit=limit)
        return [
            Document(page_content=result[self._text_field], metadata=result)
            for result in results
        ]
    except MilvusException as e:
        logger.error(f"Metadata search failed: {e}")
        return []
```

#### Testing:

I have also written a test function to verify the functionality of search_by_metadata. Let me know if any modifications or additional tests are needed.
