### PR TITLE
Fix: Correct SearchResult import path

### DIFF
--- a/libs/milvus/langchain_milvus/retrievers/milvus_hybrid_search.py
+++ b/libs/milvus/langchain_milvus/retrievers/milvus_hybrid_search.py
@@ -5,7 +5,8 @@ from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 from langchain_core.retrievers import BaseRetriever
 from pymilvus import AnnSearchRequest, Collection
-from pymilvus.client.abstract import BaseRanker, SearchResult  # type: ignore
+from pymilvus.client.abstract import BaseRanker  # type: ignore
+from pymilvus.client.search_reasult import SearchResult
 
 from langchain_milvus.utils.sparse import BaseSparseEmbedding
 

--- a/libs/milvus/pyproject.toml
+++ b/libs/milvus/pyproject.toml
@@ -26,7 +26,7 @@ ignore_missing_imports = "True"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-pymilvus = "^2.5.5"
+pymilvus = "^2.5.7"
 langchain-core = ">=0.2.38,<0.4"
 
 [tool.coverage.run]


### PR DESCRIPTION
Fix SearchResult import path due to pymilvus package restructuring

The pymilvus library has restructured their package organization, moving the SearchResult class from pymilvus.client.abstract to pymilvus.client.search_reasult module. This commit updates our import statements to align with this change:

- Remove SearchResult from the pymilvus.client.abstract import
- Add dedicated import for SearchResult from its new location

This change ensures compatibility with the latest pymilvus package structure while maintaining the same functionality.