### PR TITLE
refactor the major methods from orm to milvus client

### DIFF
--- a/libs/milvus/langchain_milvus/retrievers/milvus_hybrid_search.py
+++ b/libs/milvus/langchain_milvus/retrievers/milvus_hybrid_search.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any, Dict, List, Optional, Union
 
 from langchain_core.callbacks import CallbackManagerForRetrieverRun
@@ -46,6 +47,18 @@ class MilvusCollectionHybridSearchRetriever(BaseRetriever):
     which will be the `metadata` of a `Document` object."""
 
     def __init__(self, **kwargs: Any):
+        warnings.warn(
+            "This class is no longer the recommended way to perform hybrid retrieval "
+            "in langchain-milvus. "
+            "Please refer to the latest documentation at "
+            "https://milvus.io/docs/milvus_hybrid_search_retriever.md "
+            "or "
+            "https://"
+            "python.langchain.com/docs/integrations/vectorstores/milvus/#hybrid-search"
+            " for the recommended approach.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(**kwargs)
 
         # If some parameters are not specified, set default values

--- a/libs/milvus/poetry.lock
+++ b/libs/milvus/poetry.lock
@@ -1194,13 +1194,13 @@ typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
 name = "pymilvus"
-version = "2.5.6"
+version = "2.5.8"
 description = "Python Sdk for Milvus"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pymilvus-2.5.6-py3-none-any.whl", hash = "sha256:19796f328278974f04632a1531e602070614f6ab0865cc97e27755f622e50a6d"},
-    {file = "pymilvus-2.5.6.tar.gz", hash = "sha256:2bea0b03ed9ac3daadb1b2df8e38aa5c8f4aabd00b23a4999abb4adaebf54f59"},
+    {file = "pymilvus-2.5.8-py3-none-any.whl", hash = "sha256:6f33c9e78c041373df6a94724c90ca83448fd231aa33d6298a7a84ed2a5a0236"},
+    {file = "pymilvus-2.5.8.tar.gz", hash = "sha256:48923e7efeebcc366d32b644772796f60484e0ca1a5afc1606d21a10ed98133c"},
 ]
 
 [package.dependencies]
@@ -2323,4 +2323,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "a901610a052b7185e85435e9d6b81e4880e59c102f9f40bb58b8dd7c3a59f145"
+content-hash = "afcea2f02e6c259e5f3bc7670c7e943e192bad00fac4ef2742b77a3b03f32c18"

--- a/libs/milvus/pyproject.toml
+++ b/libs/milvus/pyproject.toml
@@ -26,7 +26,7 @@ ignore_missing_imports = "True"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-pymilvus = "^2.5.5"
+pymilvus = "^2.5.7"
 langchain-core = ">=0.2.38,<0.4"
 
 [tool.coverage.run]


### PR DESCRIPTION
In pymilvus SDK, the [ORM](https://milvus.io/api-reference/pymilvus/v2.5.x/ORM/Collection/Collection.md), and [milvus client](https://milvus.io/api-reference/pymilvus/v2.5.x/MilvusClient/Client/MilvusClient.md) are two different layer/approach SDKs.  
In the future, we recommend using milvus client SDK to get access and operate Mivus service instead of ORM SDK, so we have to refactor the usage of ORM in langchain-milvus. This PR changed the major CRUD public methods in langchain-milvus class.
BTW, the SearchResult will be removed in the future version of pymilvus, and it will be replaced by the List[List[dict]] 