### PR TITLE
Add `drop` all option & bug fix

### DIFF
--- a/libs/milvus/langchain_milvus/vectorstores/milvus.py
+++ b/libs/milvus/langchain_milvus/vectorstores/milvus.py
@@ -2288,6 +2288,10 @@ class Milvus(VectorStore):
         if fields is None:
             fields = self.fields
 
+        # Ensure the text field is included in the output fields
+        if self._text_field not in fields:
+            fields.append(self._text_field)
+
         try:
             results = self.client.query(
                 self.collection_name,

--- a/libs/milvus/langchain_milvus/vectorstores/milvus.py
+++ b/libs/milvus/langchain_milvus/vectorstores/milvus.py
@@ -412,8 +412,7 @@ class Milvus(VectorStore):
                 self.col.set_properties(self.collection_properties)
         # If need to drop old, drop it
         if drop_old and isinstance(self.col, Collection):
-            self.col.drop()
-            self.col = None
+            self.drop()
 
         # Initialize the vector store
         self._init(
@@ -421,6 +420,7 @@ class Milvus(VectorStore):
             replica_number=replica_number,
             timeout=timeout,
         )
+
 
     def _check_vector_field(
         self,
@@ -2002,6 +2002,16 @@ class Milvus(VectorStore):
                 "Failed to delete entities: %s error: %s", self.collection_name, e
             )
             return False
+
+    def drop(self) -> None:
+        """Delete all the content in the index, by dropping the (only) collection."""
+        if self.col is not None:
+            self.col.drop()
+            self.col = None
+        else:
+            logger.warning(
+                "Collection %s does not exist, nothing to drop.", self.collection_name
+            )
 
     @classmethod
     def from_texts(

--- a/libs/milvus/langchain_milvus/vectorstores/milvus.py
+++ b/libs/milvus/langchain_milvus/vectorstores/milvus.py
@@ -421,7 +421,6 @@ class Milvus(VectorStore):
             timeout=timeout,
         )
 
-
     def _check_vector_field(
         self,
         vector_field: Union[str, List[str]],
@@ -3228,6 +3227,10 @@ class Milvus(VectorStore):
         # Default to retrieving all fields if none are provided
         if fields is None:
             fields = self.fields
+
+        # Ensure the text field is included in the output fields
+        if self._text_field not in fields:
+            fields.append(self._text_field)
 
         try:
             results = await self.aclient.query(


### PR DESCRIPTION
Hi!

First, thanks for maintaining this useful wrapper for Milvus :) Using it, I encountered a small issue, and a feature that I had to implement externally; so I thought I'd add them here.

- `search_by_metadata()`: The function assumes the text field is requested by the function caller, although they might require metadata alone. Such requests currently result in an exception. Thus, to ensure text field is always returned on the database query, I suggest simply adding it, when missing.

- `drop()`: Resetting the vectorstore by dropping all rows is very useful, and in fact currently enabled only on initialization (as part of `__init__()`). I suggest to decouple it into a method (`drop()`; feel free to offer other names), exposing it for external use.

