### PR TITLE
Fix CVE-2025-68664 "Langgrinch" vulnerability

### DIFF
--- a/libs/milvus/pyproject.toml
+++ b/libs/milvus/pyproject.toml
@@ -12,7 +12,7 @@ license = {text = "MIT"}
 requires-python = ">=3.10,<4.0"
 dependencies = [
     "pymilvus>=2.6.0,<3.0",
-    "langchain-core>=1.0.0",
+    "langchain-core>=1.2.5",
 ]
 
 [project.urls]


### PR DESCRIPTION
https://cyata.ai/blog/langgrinch-langchain-core-cve-2025-68664/