### PR TITLE
fix: enforce least-privilege permissions on all workflows

### DIFF
--- a/.github/workflows/_compile_integration_test.yml
+++ b/.github/workflows/_compile_integration_test.yml
@@ -8,6 +8,9 @@ on:
         type: string
         description: "From which folder this pipeline executes"
 
+permissions:
+  contents: read
+
 env:
   POETRY_VERSION: "2.1.3"
 

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -8,6 +8,9 @@ on:
         type: string
         description: "From which folder this pipeline executes"
 
+permissions:
+  contents: read
+
 env:
   POETRY_VERSION: "2.1.3"
   WORKDIR: ${{ inputs.working-directory == '' && '.' || inputs.working-directory }}

--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -14,6 +14,9 @@ on:
         type: string
         default: "libs/milvus"
 
+permissions:
+  contents: read
+
 env:
   PYTHON_VERSION: "3.11"
   POETRY_VERSION: "2.1.3"
@@ -71,7 +74,8 @@ jobs:
     needs:
       - build
     uses: ./.github/workflows/_test_release.yml
-    permissions: write-all
+    permissions:
+      id-token: write
     with:
       working-directory: ${{ inputs.working-directory }}
     secrets: inherit

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -8,6 +8,9 @@ on:
         type: string
         description: "From which folder this pipeline executes"
 
+permissions:
+  contents: read
+
 env:
   POETRY_VERSION: "2.1.3"
 

--- a/.github/workflows/_test_release.yml
+++ b/.github/workflows/_test_release.yml
@@ -8,6 +8,9 @@ on:
         type: string
         description: "From which folder this pipeline executes"
 
+permissions:
+  contents: read
+
 env:
   POETRY_VERSION: "2.1.3"
   PYTHON_VERSION: "3.10"

--- a/.github/workflows/check_diffs.yml
+++ b/.github/workflows/check_diffs.yml
@@ -6,6 +6,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 # If another push to the same PR or branch happens while this workflow is still running,
 # cancel the earlier run in favor of the next run.
 #


### PR DESCRIPTION
## Summary
- Add top-level `permissions: contents: read` to 6 workflows that were missing explicit permission declarations (defaulting to overly broad token scopes)
- Narrow the `permissions: write-all` on the `test-pypi-publish` job in `_release.yml` to `id-token: write`, which is all trusted PyPI publishing requires
- `_codespell.yml` already had correct permissions and was left unchanged

## Test plan
- [ ] Verify CI passes on this PR (lint, test, compile-integration-test workflows all only need read access)
- [ ] Verify release workflow still works on next release (job-level `id-token: write` and `contents: write` are preserved where needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)