### PR TITLE
fix: add default search params for DiskANN

### DIFF
--- a/libs/milvus/langchain_milvus/vectorstores/milvus.py
+++ b/libs/milvus/langchain_milvus/vectorstores/milvus.py
@@ -304,6 +304,7 @@ class Milvus(VectorStore):
             "ANNOY": {"metric_type": "L2", "params": {"search_k": 10}},
             "SCANN": {"metric_type": "L2", "params": {"search_k": 10}},
             "AUTOINDEX": {"metric_type": "L2", "params": {}},
+            "DISKANN": {"metric_type": "L2", "params": {"search_list": 16}},
             "GPU_CAGRA": {
                 "metric_type": "L2",
                 "params": {


### PR DESCRIPTION
Adds default search params for Milvus DISKANN indexes.

Milvus DiskANN supports `search_list` as the search parameter, with default value `16` according to the Milvus docs:
https://milvus.io/docs/disk_index.md

Without this entry, initializing `Milvus` against an existing DISKANN-indexed collection without explicit `search_params` can raise `KeyError: 'DISKANN'`.

Checks:
- `make lint_diff`
- `make lint`
