### PR TITLE
Modernize Milvus integration dependencies

### DIFF
--- a/libs/milvus/langchain_milvus/vectorstores/milvus.py
+++ b/libs/milvus/langchain_milvus/vectorstores/milvus.py
@@ -23,7 +23,6 @@ from langchain_core.vectorstores import VectorStore
 from pymilvus import (
     AnnSearchRequest,
     AsyncMilvusClient,
-    Collection,
     CollectionSchema,
     DataType,
     Function,
@@ -65,6 +64,69 @@ DEFAULT_MILVUS_CONNECTION = {
 }
 
 Matrix = Union[List[List[float]], List[np.ndarray], np.ndarray]
+
+
+class _MilvusClientField:
+    """Minimal field view backed by MilvusClient metadata."""
+
+    def __init__(self, field_info: dict[str, Any]) -> None:
+        self.name = field_info["name"]
+
+
+class _MilvusClientSchema:
+    """Minimal schema view backed by MilvusClient metadata."""
+
+    def __init__(self, collection_info: dict[str, Any]) -> None:
+        self.fields = [
+            _MilvusClientField(field_info)
+            for field_info in collection_info.get("fields", [])
+        ]
+
+
+class _MilvusClientIndex:
+    """Minimal index view backed by MilvusClient metadata."""
+
+    def __init__(self, collection_name: str, index_info: dict[str, Any]) -> None:
+        self.collection_name = collection_name
+        self.field_name = index_info["field_name"]
+        self.index_name = index_info.get("index_name", self.field_name)
+        self.params = {
+            "metric_type": index_info.get("metric_type"),
+            "index_type": index_info.get("index_type"),
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "collection": self.collection_name,
+            "field": self.field_name,
+            "index_name": self.index_name,
+            "index_param": self.params,
+        }
+
+
+class _MilvusClientCollection:
+    """Collection-like view that avoids the PyMilvus ORM Collection API."""
+
+    def __init__(self, client: MilvusClient, collection_name: str) -> None:
+        self._client = client
+        self.name = collection_name
+
+    @property
+    def schema(self) -> _MilvusClientSchema:
+        return _MilvusClientSchema(self._client.describe_collection(self.name))
+
+    @property
+    def indexes(self) -> list[_MilvusClientIndex]:
+        return [
+            _MilvusClientIndex(self.name, self._client.describe_index(self.name, index))
+            for index in self._client.list_indexes(self.name)
+        ]
+
+    def set_properties(self, properties: dict[str, Any]) -> None:
+        self._client.alter_collection_properties(
+            collection_name=self.name,
+            properties=properties,
+        )
 
 
 def cosine_similarity(X: Matrix, Y: Matrix) -> np.ndarray:
@@ -364,6 +426,7 @@ class Milvus(VectorStore):
         self._metadata_field = metadata_field
         self._partition_key_field = partition_key_field
         self.fields: list[str] = []
+        self._dynamic_fields: set[str] = set()
         self.partition_names = partition_names
         self.replica_number = replica_number
         self.timeout = timeout
@@ -400,7 +463,7 @@ class Milvus(VectorStore):
 
         self.alias = self.client._using
 
-        self._col_cache: Optional[Collection] = None
+        self._col_cache: Optional[_MilvusClientCollection] = None
         self._cache_key: Optional[str] = None
 
         # If need to drop old, drop it
@@ -561,12 +624,13 @@ class Milvus(VectorStore):
             }
 
     @property
-    def col(self) -> Optional[Collection]:
+    def col(self) -> Optional[_MilvusClientCollection]:
         """
-        Lazy-loaded Collection object property with caching.
+        Lazy-loaded collection metadata view with caching.
 
-        Returns the ORM Collection object if the collection exists.
-        Uses cache to avoid repeated network calls and Collection() construction.
+        Returns a collection-like object if the collection exists. This avoids
+        constructing the deprecated ORM Collection API while preserving the
+        schema/index attributes used by this integration.
         """
         # Generate current cache key
         current_key = f"{self.collection_name}:{self.alias}"
@@ -575,9 +639,9 @@ class Milvus(VectorStore):
         if self._cache_key == current_key and self._col_cache is not None:
             return self._col_cache
 
-        # Cache miss - check and create Collection object
+        # Cache miss - check and create the client-backed collection view
         if self.client.has_collection(self.collection_name):
-            self._col_cache = Collection(self.collection_name, using=self.alias)
+            self._col_cache = _MilvusClientCollection(self.client, self.collection_name)
             if self.collection_properties is not None:
                 self._col_cache.set_properties(self.collection_properties)
             self._cache_key = current_key
@@ -589,7 +653,7 @@ class Milvus(VectorStore):
         return None
 
     @col.setter
-    def col(self, value: Optional[Collection]) -> None:
+    def col(self, value: Optional[_MilvusClientCollection]) -> None:
         """Collection setter for backward compatibility. Also updates cache."""
         self._col_cache = value
         if value is not None:
@@ -1015,8 +1079,10 @@ class Milvus(VectorStore):
         """
         Grab the existing fields from the Collection.
         """
-        if isinstance(self.col, Collection):
-            schema = self.col.schema
+        self.fields = []
+        col = self.col
+        if col is not None:
+            schema = col.schema
             for x in schema.fields:
                 self.fields.append(x.name)
 
@@ -1037,8 +1103,9 @@ class Milvus(VectorStore):
         if not self._is_multi_vector:
             field_name: str = field_name or self._vector_field  # type: ignore
 
-        if isinstance(self.col, Collection):
-            for x in self.col.indexes:
+        col = self.col
+        if col is not None:
+            for x in col.indexes:
                 if x.field_name == field_name:
                     return x.to_dict()
 
@@ -1289,6 +1356,8 @@ class Milvus(VectorStore):
                     if not self.enable_dynamic_field and key not in self.fields:
                         continue
                     # If enable_dynamic_field, all fields are allowed.
+                    if self.enable_dynamic_field:
+                        self._dynamic_fields.add(key)
                     entity_dict[key] = value
 
             insert_list.append(entity_dict)
@@ -1565,7 +1634,7 @@ class Milvus(VectorStore):
 
         For more information about the search parameters, take a look at the pymilvus
         documentation found here:
-        https://milvus.io/api-reference/pymilvus/v2.5.x/ORM/Collection/search.md
+        https://milvus.io/api-reference/pymilvus/v3.0.x/MilvusClient/Vector/search.md
 
         Args:
             embedding_or_text (List[float] | Dict[int, float] | str): The embedding
@@ -1576,7 +1645,7 @@ class Milvus(VectorStore):
             expr (str, optional): Filtering expression. Defaults to None.
             timeout (float, optional): How long to wait before timeout error.
                 Defaults to None.
-            kwargs: Collection.search() keyword arguments.
+            kwargs: MilvusClient.search() keyword arguments.
 
         Returns:
             List[List[dict]]: Milvus search result.
@@ -1597,10 +1666,7 @@ class Milvus(VectorStore):
             )
             param = self._as_list(self.search_params)[0]
 
-        if self.enable_dynamic_field:
-            output_fields = ["*"]
-        else:
-            output_fields = self._remove_forbidden_fields(self.fields[:])
+        output_fields = self._get_output_fields()
         col_search_res = self.client.search(
             self.collection_name,
             data=[embedding_or_text],
@@ -1632,7 +1698,7 @@ class Milvus(VectorStore):
 
         For more information about the search parameters, take a look at the pymilvus
         documentation found here:
-        https://milvus.io/api-reference/pymilvus/v2.5.x/ORM/Collection/hybrid_search.md
+        https://milvus.io/api-reference/pymilvus/v3.0.x/MilvusClient/Vector/hybrid_search.md
 
         Args:
             query (str): The text being searched.
@@ -1651,7 +1717,7 @@ class Milvus(VectorStore):
                 The parameters for the ranker. Defaults to None.
             timeout (float, optional): How long to wait before timeout error.
                 Defaults to None.
-            kwargs: Collection.hybrid_search() keyword arguments.
+            kwargs: MilvusClient.hybrid_search() keyword arguments.
 
         Returns:
             List[List[dict]]: Milvus search result.
@@ -1669,6 +1735,7 @@ class Milvus(VectorStore):
             assert (
                 reranker.type == FunctionType.RERANK
             ), f"Expected FunctionType.RERANK, got {reranker.type}"
+            # Function rerankers require Milvus 2.6+ for consistent results.
             reranker_obj = reranker
             if ranker_type is not None or ranker_params is not None:
                 warnings.warn(
@@ -1722,10 +1789,7 @@ class Milvus(VectorStore):
                 expr=expr,
             )
             search_requests.append(request)
-        if self.enable_dynamic_field:
-            output_fields = ["*"]
-        else:
-            output_fields = self._remove_forbidden_fields(self.fields[:])
+        output_fields = self._get_output_fields()
         col_search_res = self.client.hybrid_search(
             self.collection_name,
             reqs=search_requests,
@@ -1756,7 +1820,7 @@ class Milvus(VectorStore):
             expr (str, optional): Filtering expression. Defaults to None.
             timeout (int, optional): How long to wait before timeout error.
                 Defaults to None.
-            kwargs: Collection.search() keyword arguments.
+            kwargs: MilvusClient.search() keyword arguments.
 
         Returns:
             List[Document]: Document results for search.
@@ -1789,7 +1853,7 @@ class Milvus(VectorStore):
             expr (str, optional): Filtering expression. Defaults to None.
             timeout (int, optional): How long to wait before timeout error.
                 Defaults to None.
-            kwargs: Collection.search() keyword arguments.
+            kwargs: MilvusClient.search() keyword arguments.
 
         Returns:
             List[Document]: Document results for search.
@@ -1816,7 +1880,7 @@ class Milvus(VectorStore):
 
         For more information about the search parameters, take a look at the pymilvus
         documentation found here:
-        https://milvus.io/api-reference/pymilvus/v2.5.x/ORM/Collection/search.md
+        https://milvus.io/api-reference/pymilvus/v3.0.x/MilvusClient/Vector/search.md
 
         Args:
             query (str): The text being searched.
@@ -1826,7 +1890,7 @@ class Milvus(VectorStore):
             expr (str, optional): Filtering expression. Defaults to None.
             timeout (float, optional): How long to wait before timeout error.
                 Defaults to None.
-            kwargs: Collection.search() or hybrid_search() keyword arguments.
+            kwargs: MilvusClient.search() or hybrid_search() keyword arguments.
 
         Returns:
             List[Tuple[Document, float]]: List of result doc and score.
@@ -1892,7 +1956,7 @@ class Milvus(VectorStore):
 
         For more information about the search parameters, take a look at the pymilvus
         documentation found here:
-        https://milvus.io/api-reference/pymilvus/v2.5.x/ORM/Collection/search.md
+        https://milvus.io/api-reference/pymilvus/v3.0.x/MilvusClient/Vector/search.md
 
         Args:
             embedding (List[float] | Dict[int, float]): The embedding vector being
@@ -1903,7 +1967,7 @@ class Milvus(VectorStore):
             expr (str, optional): Filtering expression. Defaults to None.
             timeout (float, optional): How long to wait before timeout error.
                 Defaults to None.
-            kwargs: Collection.search() keyword arguments.
+            kwargs: MilvusClient.search() keyword arguments.
 
         Returns:
             List[Tuple[Document, float]]: Result doc and score.
@@ -1945,7 +2009,7 @@ class Milvus(VectorStore):
             expr (str, optional): Filtering expression. Defaults to None.
             timeout (float, optional): How long to wait before timeout error.
                 Defaults to None.
-            kwargs: Collection.search() keyword arguments.
+            kwargs: MilvusClient.search() keyword arguments.
 
 
         Returns:
@@ -2005,7 +2069,7 @@ class Milvus(VectorStore):
             expr (str, optional): Filtering expression. Defaults to None.
             timeout (float, optional): How long to wait before timeout error.
                 Defaults to None.
-            kwargs: Collection.search() keyword arguments.
+            kwargs: MilvusClient.search() keyword arguments.
 
         Returns:
             List[Document]: Document results for search.
@@ -2181,21 +2245,6 @@ class Milvus(VectorStore):
                 logger.warning(
                     f"Failed to clear sync schema cache for {self.collection_name}: {e}"
                 )
-
-            # Clear schema cache from async client
-            if self._async_milvus_client is not None:
-                try:
-                    async_conn = self._async_milvus_client._get_connection()
-                    if (
-                        hasattr(async_conn, "schema_cache")
-                        and self.collection_name in async_conn.schema_cache
-                    ):
-                        async_conn.schema_cache.pop(self.collection_name, None)
-                except Exception as e:
-                    logger.warning(
-                        f"Failed to clear async schema cache for "
-                        f"{self.collection_name}: {e}"
-                    )
 
     @classmethod
     def from_texts(
@@ -2455,14 +2504,21 @@ class Milvus(VectorStore):
             raise ValueError("Unrecognized ranker of type %s", ranker_type)
 
     def _remove_forbidden_fields(self, fields: List[str]) -> List[str]:
-        """Bm25 function fields are not allowed as output fields in Milvus."""
-        forbidden_fields = []
+        """Vector fields are not allowed as default output fields in Milvus."""
+        forbidden_fields = self._as_list(self._vector_field)
         for builtin_function in self._as_list(self.builtin_func):
             if builtin_function.type == FunctionType.BM25:
                 forbidden_fields.extend(
                     self._as_list(builtin_function.output_field_names)
                 )
         return [field for field in fields if field not in forbidden_fields]
+
+    def _get_output_fields(self) -> List[str]:
+        fields = self.fields[:]
+        if self.enable_dynamic_field:
+            fields.append("$meta")
+            fields.extend(sorted(self._dynamic_fields))
+        return self._remove_forbidden_fields(list(dict.fromkeys(fields)))
 
     def search_by_metadata(
         self, expr: str, fields: Optional[List[str]] = None, limit: int = 10
@@ -2709,7 +2765,7 @@ class Milvus(VectorStore):
 
         For more information about the search parameters, take a look at the pymilvus
         documentation found here:
-        https://milvus.io/api-reference/pymilvus/v2.5.x/ORM/Collection/search.md
+        https://milvus.io/api-reference/pymilvus/v3.0.x/MilvusClient/Vector/search.md
 
         Args:
             embedding_or_text (List[float] | Dict[int, float] | str): The embedding
@@ -2720,7 +2776,7 @@ class Milvus(VectorStore):
             expr (str, optional): Filtering expression. Defaults to None.
             timeout (float, optional): How long to wait before timeout error.
                 Defaults to None.
-            kwargs: Collection.search() keyword arguments.
+            kwargs: MilvusClient.search() keyword arguments.
 
         Returns:
             List[List[dict]]: Milvus search result.
@@ -2741,10 +2797,7 @@ class Milvus(VectorStore):
             )
             param = self._as_list(self.search_params)[0]
 
-        if self.enable_dynamic_field:
-            output_fields = ["*"]
-        else:
-            output_fields = self._remove_forbidden_fields(self.fields[:])
+        output_fields = self._get_output_fields()
         col_search_res = await self.aclient.search(
             self.collection_name,
             data=[embedding_or_text],
@@ -2777,7 +2830,7 @@ class Milvus(VectorStore):
 
         For more information about the search parameters, take a look at the pymilvus
         documentation found here:
-        https://milvus.io/api-reference/pymilvus/v2.5.x/ORM/Collection/hybrid_search.md
+        https://milvus.io/api-reference/pymilvus/v3.0.x/MilvusClient/Vector/hybrid_search.md
 
         Args:
             query (str): The text being searched.
@@ -2796,7 +2849,7 @@ class Milvus(VectorStore):
                 The parameters for the ranker. Defaults to None.
             timeout (float, optional): How long to wait before timeout error.
                 Defaults to None.
-            kwargs: Collection.hybrid_search() keyword arguments.
+            kwargs: MilvusClient.hybrid_search() keyword arguments.
 
         Returns:
             List[List[dict]]: Milvus search result.
@@ -2814,6 +2867,7 @@ class Milvus(VectorStore):
             assert (
                 reranker.type == FunctionType.RERANK
             ), f"Expected FunctionType.RERANK, got {reranker.type}"
+            # Function rerankers require Milvus 2.6+ for consistent results.
             reranker_obj = reranker
         elif ranker_type is not None:
             # Old way: use ranker_type and ranker_params (deprecated)
@@ -2859,10 +2913,7 @@ class Milvus(VectorStore):
                 expr=expr,
             )
             search_requests.append(request)
-        if self.enable_dynamic_field:
-            output_fields = ["*"]
-        else:
-            output_fields = self._remove_forbidden_fields(self.fields[:])
+        output_fields = self._get_output_fields()
         col_search_res = await self.aclient.hybrid_search(
             self.collection_name,
             reqs=search_requests,
@@ -2893,7 +2944,7 @@ class Milvus(VectorStore):
             expr (str, optional): Filtering expression. Defaults to None.
             timeout (int, optional): How long to wait before timeout error.
                 Defaults to None.
-            kwargs: Collection.search() keyword arguments.
+            kwargs: MilvusClient.search() keyword arguments.
 
         Returns:
             List[Document]: Document results for search.
@@ -2926,7 +2977,7 @@ class Milvus(VectorStore):
             expr (str, optional): Filtering expression. Defaults to None.
             timeout (int, optional): How long to wait before timeout error.
                 Defaults to None.
-            kwargs: Collection.search() keyword arguments.
+            kwargs: MilvusClient.search() keyword arguments.
 
         Returns:
             List[Document]: Document results for search.
@@ -2953,7 +3004,7 @@ class Milvus(VectorStore):
 
         For more information about the search parameters, take a look at the pymilvus
         documentation found here:
-        https://milvus.io/api-reference/pymilvus/v2.5.x/ORM/Collection/search.md
+        https://milvus.io/api-reference/pymilvus/v3.0.x/MilvusClient/Vector/search.md
 
         Args:
             query (str): The text being searched.
@@ -2963,7 +3014,7 @@ class Milvus(VectorStore):
             expr (str, optional): Filtering expression. Defaults to None.
             timeout (float, optional): How long to wait before timeout error.
                 Defaults to None.
-            kwargs: Collection.search() or hybrid_search() keyword arguments.
+            kwargs: MilvusClient.search() or hybrid_search() keyword arguments.
 
         Returns:
             List[Tuple[Document, float]]: List of result doc and score.
@@ -3031,7 +3082,7 @@ class Milvus(VectorStore):
 
         For more information about the search parameters, take a look at the pymilvus
         documentation found here:
-        https://milvus.io/api-reference/pymilvus/v2.5.x/ORM/Collection/search.md
+        https://milvus.io/api-reference/pymilvus/v3.0.x/MilvusClient/Vector/search.md
 
         Args:
             embedding (List[float] | Dict[int, float]): The embedding vector being
@@ -3042,7 +3093,7 @@ class Milvus(VectorStore):
             expr (str, optional): Filtering expression. Defaults to None.
             timeout (float, optional): How long to wait before timeout error.
                 Defaults to None.
-            kwargs: Collection.search() keyword arguments.
+            kwargs: MilvusClient.search() keyword arguments.
 
         Returns:
             List[Tuple[Document, float]]: Result doc and score.
@@ -3084,7 +3135,7 @@ class Milvus(VectorStore):
             expr (str, optional): Filtering expression. Defaults to None.
             timeout (float, optional): How long to wait before timeout error.
                 Defaults to None.
-            kwargs: Collection.search() keyword arguments.
+            kwargs: MilvusClient.search() keyword arguments.
 
 
         Returns:
@@ -3144,7 +3195,7 @@ class Milvus(VectorStore):
             expr (str, optional): Filtering expression. Defaults to None.
             timeout (float, optional): How long to wait before timeout error.
                 Defaults to None.
-            kwargs: Collection.search() keyword arguments.
+            kwargs: MilvusClient.search() keyword arguments.
 
         Returns:
             List[Document]: Document results for search.

--- a/libs/milvus/poetry.lock
+++ b/libs/milvus/poetry.lock
@@ -46,6 +46,18 @@ typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 trio = ["trio (>=0.31.0)"]
 
 [[package]]
+name = "cachetools"
+version = "7.1.4"
+description = "Extensible memoizing collections and decorators"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "cachetools-7.1.4-py3-none-any.whl", hash = "sha256:323dc4127934744db5b54eb4924482d7edafbf9554e820d1531c2e08c0e4ef54"},
+    {file = "cachetools-7.1.4.tar.gz", hash = "sha256:437f55a4e0c1b01a4f3077cc470e6991d47430970e36fbcb77e2be0df4fc1cd6"},
+]
+
+[[package]]
 name = "certifi"
 version = "2025.11.12"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -224,7 +236,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {test = "platform_system == \"Windows\" or sys_platform == \"win32\"", test-integration = "platform_system == \"Windows\""}
+markers = {test = "sys_platform == \"win32\" or platform_system == \"Windows\"", test-integration = "platform_system == \"Windows\""}
 
 [[package]]
 name = "coloredlogs"
@@ -245,6 +257,18 @@ humanfriendly = ">=9.1"
 cron = ["capturer (>=2.4)"]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+description = "XML bomb protection for Python stdlib modules"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+groups = ["test"]
+files = [
+    {file = "defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"},
+    {file = "defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"},
+]
+
+[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 description = "Backport of PEP 654 (exception groups)"
@@ -262,6 +286,32 @@ typing-extensions = {version = ">=4.6.0", markers = "python_version < \"3.13\""}
 
 [package.extras]
 test = ["pytest (>=6)"]
+
+[[package]]
+name = "faiss-cpu"
+version = "1.14.3"
+description = "A library for efficient similarity search and clustering of dense vectors."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "sys_platform != \"win32\""
+files = [
+    {file = "faiss_cpu-1.14.3-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:a9369863290a3f0e033757e4c10577b6ef7431f1cede394dabd0a137e4e2ed45"},
+    {file = "faiss_cpu-1.14.3-cp310-abi3-macosx_15_0_x86_64.whl", hash = "sha256:f9d0e84d909194f63f027bbd3c1e35e905e48c9345c2db6e6f24da09a6bc5906"},
+    {file = "faiss_cpu-1.14.3-cp310-abi3-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d734cfa9ac90b6a5dfed3a27cb706d05f22824703dafc3969b4e2071877a31c"},
+    {file = "faiss_cpu-1.14.3-cp310-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8780b526c06e57aad90a8c4655dfba2ff1b3195bd600ff4499752fc45159c9fc"},
+    {file = "faiss_cpu-1.14.3-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b28ba083e8c02f2c9be03783402537fd3f00d27e68799c44bf88931500ee12ec"},
+    {file = "faiss_cpu-1.14.3-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:cdcb90850cb4b7c27d270839b37bcc0dc8d1fb6a62d1e13053e51ac95061ca25"},
+    {file = "faiss_cpu-1.14.3-cp310-cp310-win_amd64.whl", hash = "sha256:20414d5c98fb6ab9eedfb3df79841865911c2d67b6efe829dc46adfeab6f51b1"},
+    {file = "faiss_cpu-1.14.3-cp311-cp311-win_amd64.whl", hash = "sha256:f278003d00c30c90cf118b98428bb96f73eba4b9dadac6993c788966d2e983bd"},
+    {file = "faiss_cpu-1.14.3-cp312-cp312-win_amd64.whl", hash = "sha256:0a5eb27184123c7ac1060c6b862978eabf0e30c1369ccf8bdb1497d35c06ad3d"},
+    {file = "faiss_cpu-1.14.3-cp313-cp313-win_amd64.whl", hash = "sha256:ea2340f675db59af8db6da4535b541ce6948d68a008989c656c292c7b0c77127"},
+    {file = "faiss_cpu-1.14.3-cp314-cp314-win_amd64.whl", hash = "sha256:54b0ea832be5bce75ef9abf1297fe4613d760bf7cfe7a963da040cb0314e8f58"},
+]
+
+[package.dependencies]
+numpy = ">=1.25"
+packaging = "*"
 
 [[package]]
 name = "filelock"
@@ -596,6 +646,18 @@ files = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.5.3"
+description = "Lightweight pipelining with Python functions"
+optional = false
+python-versions = ">=3.9"
+groups = ["test"]
+files = [
+    {file = "joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713"},
+    {file = "joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3"},
+]
+
+[[package]]
 name = "jsonpatch"
 version = "1.33"
 description = "Apply JSON-Patches (RFC 6902)"
@@ -624,29 +686,41 @@ files = [
 
 [[package]]
 name = "langchain-core"
-version = "1.1.0"
+version = "1.4.9"
 description = "Building applications with LLMs through composability"
 optional = false
-python-versions = ">=3.10.0,<4.0.0"
+python-versions = "<4.0.0,>=3.10.0"
 groups = ["main", "dev", "test", "typing"]
-files = []
-develop = false
+files = [
+    {file = "langchain_core-1.4.9-py3-none-any.whl", hash = "sha256:28e3909e2a10cc81504952d795ac0a9e014c0018121ef89d48dd396fa09ec624"},
+    {file = "langchain_core-1.4.9.tar.gz", hash = "sha256:f8078901145bed0466755277500a5a22822a7b628808c4c0a28d4fc88895fcf2"},
+]
 
 [package.dependencies]
 jsonpatch = ">=1.33.0,<2.0.0"
+langchain-protocol = ">=0.0.17"
 langsmith = ">=0.3.45,<1.0.0"
-packaging = ">=23.2.0,<26.0.0"
+packaging = ">=23.2.0"
 pydantic = ">=2.7.4,<3.0.0"
-PyYAML = ">=5.3.0,<7.0.0"
+pyyaml = ">=5.3.0,<7.0.0"
 tenacity = ">=8.1.0,<8.4.0 || >8.4.0,<10.0.0"
 typing-extensions = ">=4.7.0,<5.0.0"
+uuid-utils = ">=0.12.0,<1.0"
 
-[package.source]
-type = "git"
-url = "https://github.com/langchain-ai/langchain.git"
-reference = "HEAD"
-resolved_reference = "c6f8b0875a96215e5d835bfbf874f835a4f46e31"
-subdirectory = "libs/core"
+[[package]]
+name = "langchain-protocol"
+version = "0.0.18"
+description = "Python bindings for the LangChain agent streaming protocol"
+optional = false
+python-versions = "<4.0.0,>=3.10.0"
+groups = ["main", "dev", "test", "typing"]
+files = [
+    {file = "langchain_protocol-0.0.18-py3-none-any.whl", hash = "sha256:70b53a86fbf9cedc863555effe44da192ab02d556ddbf2cf95b8873adcf41b5a"},
+    {file = "langchain_protocol-0.0.18.tar.gz", hash = "sha256:ec3e11782f1ed0c9db38e5a9ed01b0e7a0d3fba406faa8aef6594b73c56a63e6"},
+]
+
+[package.dependencies]
+typing-extensions = ">=4.13.0,<5.0.0"
 
 [[package]]
 name = "langsmith"
@@ -720,20 +794,27 @@ files = [
 
 [[package]]
 name = "milvus-lite"
-version = "2.5.1"
-description = "A lightweight version of Milvus wrapped with Python."
+version = "3.1.0"
+description = "Lightweight version of Milvus for local development and testing"
 optional = false
-python-versions = ">=3.7"
-groups = ["test"]
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "sys_platform != \"win32\""
 files = [
-    {file = "milvus_lite-2.5.1-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:6b014453200ba977be37ba660cb2d021030375fa6a35bc53c2e1d92980a0c512"},
-    {file = "milvus_lite-2.5.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a2e031088bf308afe5f8567850412d618cfb05a65238ed1a6117f60decccc95a"},
-    {file = "milvus_lite-2.5.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:a13277e9bacc6933dea172e42231f7e6135bd3bdb073dd2688ee180418abd8d9"},
-    {file = "milvus_lite-2.5.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:25ce13f4b8d46876dd2b7ac8563d7d8306da7ff3999bb0d14b116b30f71d706c"},
+    {file = "milvus_lite-3.1.0-py3-none-any.whl", hash = "sha256:0d20fffbee3c683eca69c4732a091273123368452159581ed050c933b41a59be"},
+    {file = "milvus_lite-3.1.0.tar.gz", hash = "sha256:8d467ae81173f1ede93723a80f08d85b91988b451cd2b7bbf9b5a7cfb875e04b"},
 ]
 
 [package.dependencies]
-tqdm = "*"
+faiss-cpu = ">=1.7.4"
+grpcio = ">=1.50"
+numpy = ">=1.24"
+pyarrow = ">=15.0"
+tomli = {version = ">=2.0", markers = "python_version < \"3.11\""}
+
+[package.extras]
+chinese = ["jieba (>=0.42)"]
+dev = ["build (>=1.0)", "pytest (>=8.0)", "pytest-cov (>=5.0)"]
 
 [[package]]
 name = "mpmath"
@@ -825,6 +906,33 @@ files = [
     {file = "mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505"},
     {file = "mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"},
 ]
+
+[[package]]
+name = "nltk"
+version = "3.10.0"
+description = "Natural Language Toolkit"
+optional = false
+python-versions = ">=3.10"
+groups = ["test"]
+files = [
+    {file = "nltk-3.10.0-py3-none-any.whl", hash = "sha256:54ff84d4916d3ef127e8953bee0023f6a6b320b75d634a19e06ef056d3d244bf"},
+    {file = "nltk-3.10.0.tar.gz", hash = "sha256:4fbac1d98203cbcd1b5d94a2877fb822300072d80604a5e7fae49d2c5f84e8c1"},
+]
+
+[package.dependencies]
+click = "*"
+defusedxml = "*"
+joblib = "*"
+regex = ">=2021.8.3"
+tqdm = "*"
+
+[package.extras]
+all = ["matplotlib", "numpy", "pyparsing", "python-crfsuite", "requests", "scikit-learn", "scipy", "twython"]
+corenlp = ["requests"]
+machine-learning = ["numpy", "python-crfsuite", "scikit-learn", "scipy"]
+plot = ["matplotlib"]
+tgrep = ["pyparsing"]
+twitter = ["twython"]
 
 [[package]]
 name = "numpy"
@@ -1263,6 +1371,60 @@ files = [
 ]
 
 [[package]]
+name = "pyarrow"
+version = "25.0.0"
+description = "Python library for Apache Arrow"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "sys_platform != \"win32\""
+files = [
+    {file = "pyarrow-25.0.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:ce0ca222802087b9a8cb031a6468442cb6b67c290a45a601cac64753d34954d3"},
+    {file = "pyarrow-25.0.0-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:7d6da02ffc7a3a9bda3b7ded4cc2a27ff73969ab37153f3afd46bbbc1ba4f0f7"},
+    {file = "pyarrow-25.0.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:dbf9fa5d4bde73b1cc16377dcaaa010f971e6fa7f5083f5d44f34b50bc1d74af"},
+    {file = "pyarrow-25.0.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:b72d943ff4e10fec8d48aedb23322d8f6ea8bc2d698b81db37e73730f69e4862"},
+    {file = "pyarrow-25.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5fb2d837960f1df7f679ff9f1a55065e306347d379e0768cebf14781254d6194"},
+    {file = "pyarrow-25.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:add690feafa0953c443cdba9e9e87f5eaa198f1ea2e43a3b146ea83f202262d0"},
+    {file = "pyarrow-25.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:d293e9959b29a24c82d936d04ab2b7fd8b8d334030de2e56a99aba94f008ad7a"},
+    {file = "pyarrow-25.0.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:2e3b6544e26e393fe2cd530f523e36c1c8d3c345bbbb60cca3fd866be8322517"},
+    {file = "pyarrow-25.0.0-cp311-cp311-macosx_12_0_x86_64.whl", hash = "sha256:b724d127783b4c19f088fcdfc844cbc318809246a30307bcabd5ed02045e890e"},
+    {file = "pyarrow-25.0.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:244f98a595f70fa4fd35faa7508c4ae67e14a173397a4b3b49d2b3c360fb0062"},
+    {file = "pyarrow-25.0.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:0222f0071d13313962a88d21bf28b80d355ac39d81bfa6ff3fe00eeaf748e4be"},
+    {file = "pyarrow-25.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b58726f118c079f9d4ed7e904975d4f15fd69d0741ba511a4e2dcaa4ef16354f"},
+    {file = "pyarrow-25.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:38a2c887cb3883e241b70201688db34133b6dfadd04f03c8f9213df53770c18e"},
+    {file = "pyarrow-25.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:161649d60a7a46c613a19fd795763ea8a88c36ba997dd99d9bc66e6794ee36e8"},
+    {file = "pyarrow-25.0.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:149730a3d1f0fb59d663a0b8aa210adfd9c17c27cd94a0d143e60daea8320d4e"},
+    {file = "pyarrow-25.0.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:0721332c30fdd453fdd1fc203b2ac1f4c9db5aea28fa38d41f2574c4b068b9ec"},
+    {file = "pyarrow-25.0.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:fa1482b3da10cac2d4db6e26b81da543e237616af2ef6d466018b31ca586496f"},
+    {file = "pyarrow-25.0.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:5d1dbf24e151042f2fa3c129563f65d66674128868496fb008c4272b16bdf778"},
+    {file = "pyarrow-25.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:20887a762dd61dcc530f93a140840ab1f6aa7836b33270e42d627ab3cf11e537"},
+    {file = "pyarrow-25.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:58d1ab556b0cea1c93fdb799b24ad58adb2f2a2788dbce782a94f64ae1a5cc9b"},
+    {file = "pyarrow-25.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:3f356afe61186395c861d5cd63dc21ff7d5fa335012a4668d979257df7fea0f5"},
+    {file = "pyarrow-25.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:8831a3ba52fa7cdb78d368d968b1dcd06171e6dff5461e16d90de91d371e47bc"},
+    {file = "pyarrow-25.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:5f4bacb60f91dd2fca6c52f1b9a0012cd090e0294f1f781dc1881a247a352f8e"},
+    {file = "pyarrow-25.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:59516c822d5fd8e544aaa0dfe72f36fed5d4c24ea8390aab1bcd31d7e959c6be"},
+    {file = "pyarrow-25.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f9dbd83e91c239a1f5ee7ce13f108b5f6c0efbe40a4375260d8f08b43ad05e9"},
+    {file = "pyarrow-25.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:18dcc8cc50b5e72eae6fcbfc6c8776c21a007176b27a3cdec5c2f5bcf126708d"},
+    {file = "pyarrow-25.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4ec1895a87aa834c3b99b7a1e758747eb8bb57f922b32c0e0fa04afb8d6998b1"},
+    {file = "pyarrow-25.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:77c8d1ae46a44b4006e8db1cc977bbcc6ce4873c92f74137d68e45503b97fb18"},
+    {file = "pyarrow-25.0.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:72132b9a8a0a1840197794d4dea26080069b6b0981c116bc078762dc9691b21b"},
+    {file = "pyarrow-25.0.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:e009ef945e498dca2f050ea10d2e9764cb44017254826fc4574fdb8d2530173b"},
+    {file = "pyarrow-25.0.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:f57a39dbcb416345401c2e77a4373669b45fd111a1768e6cf267a7a0607ff0ec"},
+    {file = "pyarrow-25.0.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:447df764beb07c544f0178a5f6b70ef44b9ecf382b3cdfad4c2d7867353c3887"},
+    {file = "pyarrow-25.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ac5dfeee59f9ceb4d45ba76e83b026c38c24334135bb329d8274baa49cec3c62"},
+    {file = "pyarrow-25.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f0f100dacf2c0f400601664a79d1a907ced4740514bb2b00917341038e2ce76f"},
+    {file = "pyarrow-25.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:2e093efbecb5317372f819228fa4b4e6157eee48d3f0a7b0303705ebf81a7104"},
+    {file = "pyarrow-25.0.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:26be35b80780d2d21f4bae3d568b1666337c3a89722cc1794c956a77017cb24e"},
+    {file = "pyarrow-25.0.0-cp314-cp314t-macosx_12_0_x86_64.whl", hash = "sha256:6f4812bfbf11ca7d8faf59eb8fff8bf4dd25ce3a38b62baa010cc17a0926d1b2"},
+    {file = "pyarrow-25.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b8af8ceedf0c9c160fd2b63440f2d205b9404db85866c1217bfea601de7cfb50"},
+    {file = "pyarrow-25.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c70a5fd9a82bd1a702fd482bdc62d38dcb672fb2b449b1d7c0d7d1f4be7b7bfe"},
+    {file = "pyarrow-25.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0490a7f8b38ffe11cc26526b50c65d111cb54ddac3717cec781806793f1244dc"},
+    {file = "pyarrow-25.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e83916bbcf380866b4e14255850b33323ff678dc9758411d0409cdd2523880b0"},
+    {file = "pyarrow-25.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:13240f0d3dc5932ccd0bfa90cd76d835680b9d94a7661c635df4b703d40ce849"},
+    {file = "pyarrow-25.0.0.tar.gz", hash = "sha256:d2d697008b5ec06d75952ef260c2e9a8a0f6ccfce24266c04c9c8ade927cb3b4"},
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.4"
 description = "Data validation using Python type hints"
@@ -1435,27 +1597,28 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pymilvus"
-version = "2.6.6"
+version = "3.0.0"
 description = "Python Sdk for Milvus"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "pymilvus-2.6.6-py3-none-any.whl", hash = "sha256:0e61daa573b0025650f072493cb978a9ada9cdb1d450594707592174b1f297c0"},
-    {file = "pymilvus-2.6.6.tar.gz", hash = "sha256:2522617ea34dcc9adaad0128d230f0306962a122f08366a24dd0e84bdada1f60"},
+    {file = "pymilvus-3.0.0-1-py3-none-any.whl", hash = "sha256:57c8e7c87fbbf579f122b4df893949bc78e50bca2988527864891bd544817b05"},
 ]
 
 [package.dependencies]
+cachetools = ">=5.0.0"
 grpcio = ">=1.66.2,<1.68.0 || >1.68.0,<1.68.1 || >1.68.1,<1.69.0 || >1.69.0,<1.70.0 || >1.70.0,<1.70.1 || >1.70.1,<1.71.0 || >1.71.0,<1.72.1 || >1.72.1,<1.73.0 || >1.73.0"
 orjson = ">=3.10.15"
 pandas = ">=1.2.4"
 protobuf = ">=5.27.2"
 python-dotenv = ">=1.0.1,<2.0.0"
-setuptools = ">69"
+requests = ">=2.20.0"
+setuptools = {version = ">=78.1.1", markers = "python_version >= \"3.9\""}
 
 [package.extras]
 bulk-writer = ["azure-storage-blob", "minio (>=7.0.0)", "pyarrow (>=12.0.0)", "requests", "urllib3"]
-dev = ["Cython (>=3.0.0)", "azure-storage-blob", "black", "grpcio (==1.66.2)", "grpcio-testing (==1.66.2)", "grpcio-tools (==1.66.2)", "memray ; sys_platform != \"win32\"", "minio (>=7.0.0)", "ml_dtypes", "py-spy", "pyarrow (>=12.0.0)", "pytest (>=5.3.4)", "pytest-asyncio", "pytest-benchmark[histogram]", "pytest-cov (>=5.0.0)", "pytest-timeout (>=1.3.4)", "requests", "ruff (>=0.12.9,<1)", "scipy", "urllib3"]
+dev = ["Cython (>=3.0.0)", "azure-storage-blob", "black", "grpcio (==1.66.2) ; python_version < \"3.14\"", "grpcio-tools (==1.66.2) ; python_version < \"3.14\"", "memray ; sys_platform != \"win32\"", "minio (>=7.0.0)", "ml_dtypes", "py-spy", "pyarrow (>=12.0.0)", "pytest (>=5.3.4)", "pytest-asyncio", "pytest-benchmark[histogram]", "pytest-cov (>=5.0.0)", "pytest-timeout (>=1.3.4)", "requests", "ruff (>=0.12.9,<1)", "scipy", "urllib3"]
 milvus-lite = ["milvus-lite (>=2.4.0) ; sys_platform != \"win32\""]
 model = ["pymilvus.model (>=0.3.0)"]
 
@@ -2350,8 +2513,7 @@ version = "2.3.0"
 description = "A lil' TOML parser"
 optional = false
 python-versions = ">=3.8"
-groups = ["test", "typing"]
-markers = "python_version == \"3.10\""
+groups = ["main", "test", "typing"]
 files = [
     {file = "tomli-2.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:88bd15eb972f3664f5ed4b57c1634a97153b4bac4479dcb6a495f41921eb7f45"},
     {file = "tomli-2.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:883b1c0d6398a6a9d29b508c331fa56adbcdff647f6ace4dfca0f50e90dfd0ba"},
@@ -2396,6 +2558,7 @@ files = [
     {file = "tomli-2.3.0-py3-none-any.whl", hash = "sha256:e95b1af3c5b07d9e643909b5abbec77cd9f1217e6d0bca72b0234736b9fb1f1b"},
     {file = "tomli-2.3.0.tar.gz", hash = "sha256:64be704a875d2a59753d80ee8a533c3fe183e3f06807ff7dc2232938ccb01549"},
 ]
+markers = {main = "sys_platform != \"win32\" and python_version == \"3.10\"", test = "python_version == \"3.10\"", typing = "python_version == \"3.10\""}
 
 [[package]]
 name = "tqdm"
@@ -3002,4 +3165,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "60ed4ade69fd3da9b939d7dc0dcb4248d027586538c78babaa406b5dda13f4f5"
+content-hash = "daee1f660b636d22badd8fbda42ce099501dd0d9919b752c7d779eb9d0a21cd0"

--- a/libs/milvus/pyproject.toml
+++ b/libs/milvus/pyproject.toml
@@ -4,15 +4,16 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "langchain-milvus"
-version = "0.3.3"
+version = "0.4.0"
 description = "An integration package connecting Milvus and LangChain"
 authors = []
 readme = "README.md"
-license = {text = "MIT"}
+license = "MIT"
 requires-python = ">=3.10,<4.0"
 dependencies = [
-    "pymilvus>=2.6.0,<3.0",
-    "langchain-core>=1.0.0",
+    "pymilvus>=3.0.0,<4.0",
+    "milvus-lite>=3.1.0,<4.0; sys_platform != 'win32'",
+    "langchain-core>=1.4.9,<2.0.0",
 ]
 
 [project.urls]
@@ -65,9 +66,9 @@ syrupy = "^4.0.2"
 pytest-watcher = "^0.3.4"
 pytest-asyncio = "^0.21.1"
 "pymilvus.model" = "^0.3.1"
-milvus-lite = "^2.5.1"
+nltk = ">=3.9.1,<4.0"
 onnxruntime = "^1.19.2"
-langchain-core = { git = "https://github.com/langchain-ai/langchain.git", subdirectory = "libs/core" }
+langchain-core = ">=1.4.9,<2.0.0"
 
 [tool.poetry.group.codespell.dependencies]
 codespell = "^2.2.0"
@@ -83,7 +84,7 @@ ruff = "^0.1.5"
 mypy = "^1.11"
 types-requests = "^2"
 simsimd = "^5.0.0"
-langchain-core = { git = "https://github.com/langchain-ai/langchain.git", subdirectory = "libs/core" }
+langchain-core = ">=1.4.9,<2.0.0"
 
 [tool.poetry.group.dev.dependencies]
-langchain-core = { git = "https://github.com/langchain-ai/langchain.git", subdirectory = "libs/core" }
+langchain-core = ">=1.4.9,<2.0.0"

--- a/libs/milvus/tests/test_milvus_base.py
+++ b/libs/milvus/tests/test_milvus_base.py
@@ -302,6 +302,28 @@ class TestMilvusBase(ABC):
             docsearch._vector_field,
         }
 
+    def test_milvus_reconnect_dynamic_field_metadata(self) -> None:
+        """Test dynamic metadata retrieval after reconnecting to a collection."""
+        texts = ["foo", "bar", "baz"]
+        metadatas = [{"id": i} for i in range(len(texts))]
+        docsearch = self._milvus_from_texts(
+            metadatas=metadatas, enable_dynamic_field=True
+        )
+        reconnected = Milvus(
+            FakeEmbeddings(),
+            connection_args={"uri": self.TEST_URI},
+            collection_name=docsearch.collection_name,
+            drop_old=False,
+            consistency_level="Strong",
+            enable_dynamic_field=True,
+        )
+
+        output = reconnected.similarity_search("foo", k=1)
+
+        assert_docs_equal_without_pk(
+            output, [Document(page_content="foo", metadata={"id": 0})]
+        )
+
     def test_milvus_disable_dynamic_field(self) -> None:
         """Test end to end construction and disable dynamic field"""
         texts = ["foo", "bar", "baz"]

--- a/libs/milvus/tests/test_milvus_base_async.py
+++ b/libs/milvus/tests/test_milvus_base_async.py
@@ -303,6 +303,29 @@ class TestMilvusBaseAsync(ABC):
         }
 
     @pytest.mark.asyncio
+    async def test_milvus_reconnect_dynamic_field_metadata(self) -> None:
+        """Test dynamic metadata retrieval after reconnecting to a collection."""
+        texts = ["foo", "bar", "baz"]
+        metadatas = [{"id": i} for i in range(len(texts))]
+        docsearch = await self._milvus_from_texts(
+            metadatas=metadatas, enable_dynamic_field=True
+        )
+        reconnected = Milvus(
+            FakeEmbeddings(),
+            connection_args={"uri": self.TEST_URI},
+            collection_name=docsearch.collection_name,
+            drop_old=False,
+            consistency_level="Strong",
+            enable_dynamic_field=True,
+        )
+
+        output = await reconnected.asimilarity_search("foo", k=1)
+
+        assert_docs_equal_without_pk(
+            output, [Document(page_content="foo", metadata={"id": 0})]
+        )
+
+    @pytest.mark.asyncio
     async def test_milvus_disable_dynamic_field(self) -> None:
         """Test end to end construction and disable dynamic field"""
         texts = ["foo", "bar", "baz"]

--- a/libs/milvus/tests/unit_tests/vectorstores/test_milvus.py
+++ b/libs/milvus/tests/unit_tests/vectorstores/test_milvus.py
@@ -42,6 +42,12 @@ class TestMilvusLite(TestMilvusBase):
         return super().test_milvus_enable_dynamic_field()
 
     @pytest.mark.skip(
+        reason="Milvus-Lite doesn't return unknown dynamic fields via $meta yet"
+    )
+    def test_milvus_reconnect_dynamic_field_metadata(self) -> None:
+        return super().test_milvus_reconnect_dynamic_field_metadata()
+
+    @pytest.mark.skip(
         reason="Milvus-Lite doesn't support built-in full-text search yet"
     )
     def test_milvus_builtin_bm25_function(self, enable_dynamic_field: bool) -> None:
@@ -50,3 +56,13 @@ class TestMilvusLite(TestMilvusBase):
     @pytest.mark.skip(reason="Milvus-Lite doesn't support Function as rerank input")
     def test_milvus_multi_vector_search_with_ranker(self) -> None:
         return super().test_milvus_multi_vector_search_with_ranker()
+
+    @pytest.mark.skip(
+        reason="Milvus-Lite doesn't support filtering dynamic array fields yet"
+    )
+    def test_milvus_array_field(self) -> None:
+        return super().test_milvus_array_field()
+
+    @pytest.mark.skip(reason="Milvus-Lite doesn't support FLOAT16_VECTOR yet")
+    def test_milvus_vector_field(self) -> None:
+        return super().test_milvus_vector_field()


### PR DESCRIPTION
Update the major dependencies , especially pymilvus -> 3.0.0+ , milvus-lite 3.1.0+, to adapt the latest milvus/zilliz backend better