### PR TITLE
Fix release Milvus startup timeout

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -167,12 +167,12 @@ jobs:
         run: |
           mkdir -p milvus_temp
           cd milvus_temp
-          wget https://raw.githubusercontent.com/milvus-io/milvus/master/scripts/standalone_embed.sh
+          wget https://raw.githubusercontent.com/milvus-io/milvus/v2.6.4/scripts/standalone_embed.sh
           
           # Setup Milvus with OpenAI credentials
           python3 $GITHUB_WORKSPACE/.github/scripts/setup_milvus_with_apikey.py standalone_embed.sh
           
-          bash standalone_embed.sh start
+          timeout 300 bash standalone_embed.sh start
           cd ..
           sleep 5
           echo "Milvus server with OpenAI API key configured!"


### PR DESCRIPTION
fix to release new version，pin the milvus version at 2.6, because currently, the 3.0 version is still beta