### PR TITLE
fix: don't pass timeout to insert twice when creating a collection

### DIFF
--- a/libs/milvus/langchain_milvus/vectorstores/milvus.py
+++ b/libs/milvus/langchain_milvus/vectorstores/milvus.py
@@ -1541,14 +1541,14 @@ class Milvus(VectorStore):
 
         # If the collection hasn't been initialized yet, perform all steps to do so
         if not self.client.has_collection(self.collection_name):
-            kwargs = {"embeddings": embeddings, "metadatas": metadatas}
+            init_kwargs: dict = {"embeddings": embeddings, "metadatas": metadatas}
             if self.partition_names:
-                kwargs["partition_names"] = self.partition_names
+                init_kwargs["partition_names"] = self.partition_names
             if self.replica_number:
-                kwargs["replica_number"] = self.replica_number
+                init_kwargs["replica_number"] = self.replica_number
             if self.timeout:
-                kwargs["timeout"] = self.timeout
-            self._init(**kwargs)
+                init_kwargs["timeout"] = self.timeout
+            self._init(**init_kwargs)
 
         insert_list = self._prepare_insert_list(
             texts=texts,

--- a/libs/milvus/tests/test_milvus_base.py
+++ b/libs/milvus/tests/test_milvus_base.py
@@ -97,6 +97,22 @@ class TestMilvusBase(ABC):
         output = docsearch.similarity_search("foo", k=1)
         assert_docs_equal_without_pk(output, [Document(page_content="foo")])
 
+    def test_milvus_add_texts_with_timeout_new_collection(self) -> None:
+        """Inserting into a not-yet-created collection while a timeout is set
+        must not pass timeout to the client twice (issue #91)."""
+        docsearch = Milvus(
+            FakeEmbeddings(),
+            connection_args={"uri": self.TEST_URI},
+            collection_name="test_timeout_new_collection",
+            drop_old=True,
+            consistency_level="Strong",
+            auto_id=True,
+            timeout=30,
+        )
+        docsearch.add_texts(["foo", "bar"])
+        output = docsearch.similarity_search("foo", k=1)
+        assert len(output) == 1
+
     def test_milvus_vector_search(self) -> None:
         """Test end to end construction and search by vector."""
         docsearch = self._milvus_from_texts()


### PR DESCRIPTION
Fixes #91.

If the collection doesn't exist yet and a `timeout` is set, `add_texts`/`add_embeddings` crash with `insert() got multiple values for keyword argument 'timeout'`. The init block reused the function's own `**kwargs` for the collection-creation args (`embeddings`, `metadatas`, `timeout`), and that same dict later gets splatted into `client.insert(..., timeout=timeout, **kwargs)`, so timeout lands twice. Gave init its own dict.

Added a Milvus Lite test that sets `timeout` and inserts into a fresh collection. Fails on `main`.